### PR TITLE
Remove deduplicate mod token in grammar.js

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -170,7 +170,7 @@ module.exports = grammar({
       /[/_\-=->,;:::!=?.@*&#%^+<>|~]+/,
       '\'',
       'abi', 'as', 'break', 'configurable', 'const', 'continue', 'default', 'mod', 'enum', 'fn', 'for', 'if', 'impl',
-      'let', 'match', 'mod', 'pub', 'return', 'storage', 'struct', 'trait', 'type', 'use', 'where', 'while',
+      'let', 'match', 'pub', 'return', 'storage', 'struct', 'trait', 'type', 'use', 'where', 'while',
     ),
 
     // Section - Declarations


### PR DESCRIPTION
`mod` was accidentally listed twice in _non_special_token in grammar.js. I removed the extra entry to keep the grammar clean and avoid confusion. 